### PR TITLE
Upgrade to Python 3.6

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.5'
+          python-version: '3.6'
 
       - name: Install pipenv
         run: pip install pipenv

--- a/Pipfile
+++ b/Pipfile
@@ -15,4 +15,4 @@ tqdm = "*"
 pandas = "*"
 
 [requires]
-python_version = "3.5"
+python_version = "3.6"


### PR DESCRIPTION
Support for Python 3.5 ended on the 13th of September 2020.