### PR TITLE
Upgraded GitHub Actions runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   web:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: build
 
     steps:

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   web:
     name: Report
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: build
 
     steps:


### PR DESCRIPTION
Ubuntu 20.04 LTS runner was removed on 2025-04-15.